### PR TITLE
Add recipes, change orders

### DIFF
--- a/src/main/java/com/vanillastar/vsbrewing/mixin/potion/PotionsMixin.java
+++ b/src/main/java/com/vanillastar/vsbrewing/mixin/potion/PotionsMixin.java
@@ -1,0 +1,46 @@
+package com.vanillastar.vsbrewing.mixin.potion;
+
+import static com.vanillastar.vsbrewing.potion.StrongWeaknessPotionKt.STRONG_WEAKNESS_POTION_ID;
+import static com.vanillastar.vsbrewing.utils.LoggerHelperKt.getLogger;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.entity.effect.StatusEffectInstance;
+import net.minecraft.entity.effect.StatusEffects;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.Potions;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
+
+@Mixin(Potions.class)
+public abstract class PotionsMixin {
+  @ModifyArgs(
+      method = "<clinit>",
+      at =
+          @At(
+              value = "INVOKE",
+              target =
+                  "Lnet/minecraft/potion/Potions;register(Ljava/lang/String;Lnet/minecraft/potion/Potion;)Lnet/minecraft/registry/entry/RegistryEntry;"))
+  private static void registerPotions(@NotNull Args args) {
+    // Inject before Potions.LUCK registration, which occurs immediately after Potions.LONG_WEAKNESS
+    // registration.
+    String name = args.get(0);
+    if (!name.equals("luck")) {
+      return;
+    }
+    Registry.registerReference(
+        Registries.POTION,
+        STRONG_WEAKNESS_POTION_ID,
+        new Potion(
+            "weakness",
+            new StatusEffectInstance(
+                StatusEffects.WEAKNESS,
+                15 * SharedConstants.TICKS_PER_SECOND,
+                /* amplifier= */ 1)));
+    getLogger().info("Registered potion {}", STRONG_WEAKNESS_POTION_ID);
+  }
+}

--- a/src/main/java/com/vanillastar/vsbrewing/mixin/recipe/BrewingRecipeRegistryBuilderMixin.java
+++ b/src/main/java/com/vanillastar/vsbrewing/mixin/recipe/BrewingRecipeRegistryBuilderMixin.java
@@ -32,7 +32,7 @@ public abstract class BrewingRecipeRegistryBuilderMixin {
       RegistryEntry<Potion> input, Item ingredient, RegistryEntry<Potion> output, CallbackInfo ci) {
     String recipeString = getRecipeString(input, ingredient, output);
     if (recipeString.equals(getRecipeString(Potions.WATER, Items.REDSTONE, Potions.MUNDANE))) {
-      LOGGER.info("Unregistered brewing recipe: {}", recipeString);
+      LOGGER.info("Deregistered brewing recipe: {}", recipeString);
       ci.cancel();
     }
   }

--- a/src/main/java/com/vanillastar/vsbrewing/mixin/recipe/BrewingRecipeRegistryBuilderMixin.java
+++ b/src/main/java/com/vanillastar/vsbrewing/mixin/recipe/BrewingRecipeRegistryBuilderMixin.java
@@ -1,0 +1,39 @@
+package com.vanillastar.vsbrewing.mixin.recipe;
+
+import static com.vanillastar.vsbrewing.utils.LoggerHelperKt.getLogger;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.Items;
+import net.minecraft.potion.Potion;
+import net.minecraft.potion.Potions;
+import net.minecraft.recipe.BrewingRecipeRegistry;
+import net.minecraft.registry.entry.RegistryEntry;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BrewingRecipeRegistry.Builder.class)
+public abstract class BrewingRecipeRegistryBuilderMixin {
+  @Unique
+  private static final Logger LOGGER = getLogger();
+
+  @Unique
+  private static @NotNull String getRecipeString(
+      RegistryEntry<Potion> input, Item ingredient, RegistryEntry<Potion> output) {
+    return String.format("%s + %s = %s", input, ingredient, output);
+  }
+
+  @Inject(method = "registerPotionRecipe", at = @At("HEAD"), cancellable = true)
+  private void removeBrewingRecipes(
+      RegistryEntry<Potion> input, Item ingredient, RegistryEntry<Potion> output, CallbackInfo ci) {
+    String recipeString = getRecipeString(input, ingredient, output);
+    if (recipeString.equals(getRecipeString(Potions.WATER, Items.REDSTONE, Potions.MUNDANE))) {
+      LOGGER.info("Unregistered brewing recipe: {}", recipeString);
+      ci.cancel();
+    }
+  }
+}

--- a/src/main/kotlin/com/vanillastar/vsbrewing/item/GlassFlaskItem.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/item/GlassFlaskItem.kt
@@ -16,7 +16,9 @@ import net.minecraft.world.World
 import net.minecraft.world.event.GameEvent
 
 val GLASS_FLASK_ITEM_METADATA =
-    ModItemMetadata("glass_flask", ItemGroups.INGREDIENTS) { it.maxCount(64) }
+    ModItemMetadata("glass_flask", ItemGroups.INGREDIENTS, /* previousItem= */ Items.GLASS_BOTTLE) {
+      it.maxCount(64)
+    }
 
 class GlassFlaskItem(settings: Settings) : Item(settings) {
   override fun use(world: World, player: PlayerEntity, hand: Hand): TypedActionResult<ItemStack> {

--- a/src/main/kotlin/com/vanillastar/vsbrewing/item/ItemHelper.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/item/ItemHelper.kt
@@ -17,6 +17,8 @@ data class ModItemMetadata(
     val name: String,
     /** [RegistryKey] for this [Item] in the creative-mode inventory. */
     val itemGroup: RegistryKey<ItemGroup>,
+    /** [Item] which must come before this item in the creative-mode inventory. */
+    val previousItem: Item?,
     /** Visibility behaviors for this [Item] in the creative-mode inventory. */
     val itemGroupVisibilities: List<ModItemGroupVisibilityMetadata>,
     /** Settings for this [Item]. */
@@ -25,10 +27,12 @@ data class ModItemMetadata(
   constructor(
       name: String,
       itemGroup: RegistryKey<ItemGroup>,
+      previousItem: Item,
       settingsProvider: (Item.Settings) -> Item.Settings,
   ) : this(
       name,
       itemGroup,
+      previousItem,
       listOf(ModItemGroupVisibilityMetadata(ItemGroup.StackVisibility.PARENT_AND_SEARCH_TABS) {}),
       settingsProvider,
   )

--- a/src/main/kotlin/com/vanillastar/vsbrewing/item/ModItems.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/item/ModItems.kt
@@ -23,10 +23,10 @@ abstract class ModItems : ModRegistry() {
       val stack = ItemStack(item)
       stackProvider(stack)
       ItemGroupEvents.modifyEntriesEvent(metadata.itemGroup).register {
-        if (metadata.previousItem != null) {
-          it.addAfter(metadata.previousItem, listOf(stack), visibility)
-        } else {
+        if (metadata.previousItem == null) {
           it.add(stack, visibility)
+        } else {
+          it.addAfter(metadata.previousItem, listOf(stack), visibility)
         }
       }
     }

--- a/src/main/kotlin/com/vanillastar/vsbrewing/item/ModItems.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/item/ModItems.kt
@@ -22,7 +22,13 @@ abstract class ModItems : ModRegistry() {
     for ((visibility, stackProvider) in metadata.itemGroupVisibilities) {
       val stack = ItemStack(item)
       stackProvider(stack)
-      ItemGroupEvents.modifyEntriesEvent(metadata.itemGroup).register { it.add(stack, visibility) }
+      ItemGroupEvents.modifyEntriesEvent(metadata.itemGroup).register {
+        if (metadata.previousItem != null) {
+          it.addAfter(metadata.previousItem, listOf(stack), visibility)
+        } else {
+          it.add(stack, visibility)
+        }
+      }
     }
     logger.info(
         "Registered item {} in group {}|{}",

--- a/src/main/kotlin/com/vanillastar/vsbrewing/item/PotionFlaskItem.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/item/PotionFlaskItem.kt
@@ -3,18 +3,26 @@ package com.vanillastar.vsbrewing.item
 import com.vanillastar.vsbrewing.component.MOD_COMPONENTS
 import com.vanillastar.vsbrewing.utils.getModIdentifier
 import kotlin.streams.asStream
+import net.minecraft.SharedConstants
 import net.minecraft.advancement.criterion.Criteria
 import net.minecraft.block.Blocks
 import net.minecraft.component.DataComponentTypes
+import net.minecraft.component.type.AttributeModifiersComponent
 import net.minecraft.component.type.PotionContentsComponent
 import net.minecraft.entity.LivingEntity
+import net.minecraft.entity.attribute.EntityAttribute
+import net.minecraft.entity.attribute.EntityAttributeModifier
+import net.minecraft.entity.effect.StatusEffectInstance
+import net.minecraft.entity.effect.StatusEffectUtil
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.item.*
 import net.minecraft.item.tooltip.TooltipType
 import net.minecraft.particle.ParticleTypes
 import net.minecraft.potion.Potions
 import net.minecraft.registry.Registries
+import net.minecraft.registry.entry.RegistryEntry
 import net.minecraft.registry.tag.BlockTags
+import net.minecraft.screen.ScreenTexts
 import net.minecraft.server.network.ServerPlayerEntity
 import net.minecraft.server.world.ServerWorld
 import net.minecraft.sound.SoundCategory
@@ -32,6 +40,7 @@ val POTION_FLASK_ITEM_METADATA =
     ModItemMetadata(
         "potion_flask",
         ItemGroups.FOOD_AND_DRINK,
+        /* previousItem= */ null,
         Registries.POTION.streamEntries()
             .flatMap { potion ->
               (PotionFlaskItem.MAX_USES downTo 1)
@@ -57,8 +66,10 @@ val POTION_FLASK_ITEM_METADATA =
 
 class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
   companion object {
+    /** Maximum number of uses for a [PotionFlaskItem]. */
     const val MAX_USES = 3
 
+    /** Translation key for the tooltip indicating number of remaining uses. */
     private val remainingUsesTranslationKey =
         "${
         Util.createTranslationKey(
@@ -66,6 +77,104 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
           getModIdentifier(POTION_FLASK_ITEM_METADATA.name),
         )
       }.remaining_uses"
+
+    /**
+     * Builds the item tooltip displaying this potion flask's effects.
+     *
+     * This logic is mostly copied from [PotionContentsComponent.buildTooltip], since we wish to
+     * insert our own tooltip within the default potion tooltip. Injecting into the function with a
+     * mixin would be too fragile in this case.
+     */
+    private fun buildEffectsTooltip(
+        effects: Iterable<StatusEffectInstance>,
+        tickRate: Float,
+        textConsumer: (Text) -> Unit,
+    ) {
+      if (effects.none()) {
+        textConsumer(Text.translatable("effect.none").formatted(Formatting.GRAY))
+        return
+      }
+
+      for (effect in effects) {
+        var mutableText = Text.translatable(effect.translationKey)
+        if (effect.amplifier > 0) {
+          mutableText =
+              Text.translatable(
+                  "potion.withAmplifier",
+                  mutableText,
+                  Text.translatable("potion.potency." + effect.amplifier),
+              )
+        }
+        if (!effect.isDurationBelow(SharedConstants.TICKS_PER_SECOND)) {
+          mutableText =
+              Text.translatable(
+                  "potion.withDuration",
+                  mutableText,
+                  StatusEffectUtil.getDurationText(effect, /* multiplier= */ 1.0f, tickRate),
+              )
+        }
+        textConsumer(mutableText.formatted(effect.effectType.value().category.formatting))
+      }
+    }
+
+    /**
+     * Builds the item tooltip displaying what happens when this potion flask is used.
+     *
+     * This logic is mostly copied from [PotionContentsComponent.buildTooltip], since we wish to
+     * insert our own tooltip within the default potion tooltip. Injecting into the function with a
+     * mixin would be too fragile in this case.
+     */
+    private fun buildUsageTooltip(
+        effects: Iterable<StatusEffectInstance>,
+        textConsumer: (Text) -> Unit,
+    ) {
+      val effectDataList =
+          mutableListOf<Pair<RegistryEntry<EntityAttribute>, EntityAttributeModifier>>()
+      for (statusEffectInstance in effects) {
+        statusEffectInstance.effectType.value().forEachAttributeModifier(
+            statusEffectInstance.amplifier
+        ) { attribute, modifier ->
+          effectDataList.add(Pair(attribute, modifier))
+        }
+      }
+
+      if (effectDataList.none { (_, modifier) -> modifier.value != 0.0 }) {
+        return
+      }
+
+      textConsumer(ScreenTexts.EMPTY)
+      textConsumer(Text.translatable("potion.whenDrank").formatted(Formatting.DARK_PURPLE))
+
+      for ((attribute, modifier) in effectDataList) {
+        var modifierDisplayValue =
+            modifier.value *
+                when (modifier.operation) {
+                  EntityAttributeModifier.Operation.ADD_MULTIPLIED_BASE -> 100
+                  EntityAttributeModifier.Operation.ADD_MULTIPLIED_TOTAL -> 100
+                  else -> 1
+                }
+
+        var modifierTranslationKeyPrefix: String
+        var formatting: Formatting
+        if (modifier.value >= 0.0) {
+          modifierTranslationKeyPrefix = "attribute.modifier.plus"
+          formatting = Formatting.BLUE
+        } else {
+          modifierDisplayValue *= -1
+          modifierTranslationKeyPrefix = "attribute.modifier.take"
+          formatting = Formatting.RED
+        }
+
+        textConsumer(
+            Text.translatable(
+                    "${modifierTranslationKeyPrefix}.${modifier.operation.id}",
+                    AttributeModifiersComponent.DECIMAL_FORMAT.format(modifierDisplayValue),
+                    Text.translatable(attribute.value().translationKey),
+                )
+                .formatted(formatting)
+        )
+      }
+    }
   }
 
   override fun getDefaultStack(): ItemStack {
@@ -74,6 +183,10 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
     return stack
   }
 
+  /**
+   * This is mostly copied from [PotionItem.finishUsing], except we try to decrement the potion
+   * flask's remaining uses instead of immediately emptying the flask.
+   */
   override fun finishUsing(stack: ItemStack, world: World, user: LivingEntity): ItemStack {
     val player = user as? PlayerEntity
     if (player is ServerPlayerEntity) {
@@ -95,7 +208,9 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
     }
 
     player?.incrementStat(Stats.USED.getOrCreateStat(this))
+
     if (player?.isInCreativeMode != true) {
+      // If applicable, decrement remaining uses instead of discarding item.
       val remainingUses =
           stack.getOrDefault(MOD_COMPONENTS.potionFlaskRemainingUsesComponent, MAX_USES)
       if (remainingUses > 1) {
@@ -112,6 +227,10 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
     return stack
   }
 
+  /**
+   * This is copied mostly from [PotionItem.useOnBlock], except we try to decrement the potion
+   * flask's remaining uses instead of immediately emptying the flask.
+   */
   override fun useOnBlock(context: ItemUsageContext): ActionResult {
     val world = context.world
     val blockPos = context.blockPos
@@ -138,6 +257,8 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
     )
 
     player?.incrementStat(Stats.USED.getOrCreateStat(stack.item))
+
+    // If applicable, decrement remaining uses instead of discarding item.
     val remainingUses = stack.getOrDefault(MOD_COMPONENTS.potionFlaskRemainingUsesComponent, 0)
     if (remainingUses > 1 && player?.isInCreativeMode != true) {
       stack.set(MOD_COMPONENTS.potionFlaskRemainingUsesComponent, remainingUses - 1)
@@ -185,7 +306,10 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
       tooltip: MutableList<Text>,
       type: TooltipType,
   ) {
-    super.appendTooltip(stack, context, tooltip, type)
+    val effects = stack.get(DataComponentTypes.POTION_CONTENTS)?.effects
+    if (effects != null) {
+      buildEffectsTooltip(effects, context.updateTickRate) { tooltip.add(it) }
+    }
     tooltip.add(
         Text.translatable(
                 remainingUsesTranslationKey,
@@ -193,5 +317,8 @@ class PotionFlaskItem(settings: Settings) : PotionItem(settings) {
             )
             .formatted(Formatting.GRAY)
     )
+    if (effects != null) {
+      buildUsageTooltip(effects) { tooltip.add(it) }
+    }
   }
 }

--- a/src/main/kotlin/com/vanillastar/vsbrewing/potion/StrongWeaknessPotion.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/potion/StrongWeaknessPotion.kt
@@ -1,0 +1,5 @@
+package com.vanillastar.vsbrewing.potion
+
+import com.vanillastar.vsbrewing.utils.getModIdentifier
+
+@JvmField val STRONG_WEAKNESS_POTION_ID = getModIdentifier("strong_weakness")

--- a/src/main/kotlin/com/vanillastar/vsbrewing/recipe/ModBrewingRecipes.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/recipe/ModBrewingRecipes.kt
@@ -1,19 +1,73 @@
 package com.vanillastar.vsbrewing.recipe
 
 import com.vanillastar.vsbrewing.item.MOD_ITEMS
+import com.vanillastar.vsbrewing.potion.STRONG_WEAKNESS_POTION_ID
 import com.vanillastar.vsbrewing.utils.ModRegistry
 import net.fabricmc.fabric.api.registry.FabricBrewingRecipeRegistryBuilder
 import net.minecraft.item.Item
+import net.minecraft.item.Items
+import net.minecraft.potion.Potion
+import net.minecraft.potion.Potions
+import net.minecraft.registry.Registries
+import net.minecraft.registry.entry.RegistryEntry
 
 abstract class ModBrewingRecipes : ModRegistry() {
   override fun initialize() {
     FabricBrewingRecipeRegistryBuilder.BUILD.register {
+      val strongWeaknessPotion = Registries.POTION.getEntry(STRONG_WEAKNESS_POTION_ID).get()
+
       fun registerPotionType(item: Item) {
         it.registerPotionType(item)
         logger.info("Registered potion type {}", item)
       }
 
+      fun registerPotionRecipe(
+          input: RegistryEntry<Potion>,
+          ingredient: Item,
+          output: RegistryEntry<Potion>,
+      ) {
+        it.registerPotionRecipe(input, ingredient, output)
+        logger.info(
+            "Registered potion recipe: {} + {} = {}",
+            input.idAsString,
+            ingredient,
+            output.idAsString,
+        )
+      }
+
       registerPotionType(MOD_ITEMS.potionFlaskItem)
+
+      registerPotionRecipe(Potions.WATER, Items.REDSTONE, Potions.THICK)
+
+      registerPotionRecipe(Potions.AWKWARD, Items.POISONOUS_POTATO, Potions.POISON)
+
+      registerPotionRecipe(Potions.REGENERATION, Items.FERMENTED_SPIDER_EYE, Potions.POISON)
+      registerPotionRecipe(
+          Potions.LONG_REGENERATION,
+          Items.FERMENTED_SPIDER_EYE,
+          Potions.LONG_POISON,
+      )
+      registerPotionRecipe(
+          Potions.STRONG_REGENERATION,
+          Items.FERMENTED_SPIDER_EYE,
+          Potions.STRONG_POISON,
+      )
+
+      registerPotionRecipe(Potions.STRENGTH, Items.FERMENTED_SPIDER_EYE, Potions.WEAKNESS)
+      registerPotionRecipe(Potions.LONG_STRENGTH, Items.FERMENTED_SPIDER_EYE, Potions.LONG_WEAKNESS)
+      registerPotionRecipe(
+          Potions.STRONG_STRENGTH,
+          Items.FERMENTED_SPIDER_EYE,
+          strongWeaknessPotion,
+      )
+
+      registerPotionRecipe(
+          Potions.STRONG_SWIFTNESS,
+          Items.FERMENTED_SPIDER_EYE,
+          Potions.STRONG_SLOWNESS,
+      )
+
+      registerPotionRecipe(Potions.WEAKNESS, Items.GLOWSTONE_DUST, strongWeaknessPotion)
     }
   }
 }

--- a/src/main/kotlin/com/vanillastar/vsbrewing/recipe/ModBrewingRecipes.kt
+++ b/src/main/kotlin/com/vanillastar/vsbrewing/recipe/ModBrewingRecipes.kt
@@ -41,6 +41,10 @@ abstract class ModBrewingRecipes : ModRegistry() {
 
       registerPotionRecipe(Potions.AWKWARD, Items.POISONOUS_POTATO, Potions.POISON)
 
+      registerPotionRecipe(Potions.STRONG_LEAPING, Items.POISONOUS_POTATO, Potions.STRONG_SLOWNESS)
+
+      registerPotionRecipe(Potions.LONG_POISON, Items.FERMENTED_SPIDER_EYE, Potions.HARMING)
+
       registerPotionRecipe(Potions.REGENERATION, Items.FERMENTED_SPIDER_EYE, Potions.POISON)
       registerPotionRecipe(
           Potions.LONG_REGENERATION,

--- a/src/main/resources/vsbrewing.mixins.json
+++ b/src/main/resources/vsbrewing.mixins.json
@@ -2,7 +2,9 @@
   "required": true,
   "package": "com.vanillastar.vsbrewing.mixin",
   "compatibilityLevel": "JAVA_21",
-  "mixins": [],
+  "mixins": [
+    "potion.PotionsMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   }

--- a/src/main/resources/vsbrewing.mixins.json
+++ b/src/main/resources/vsbrewing.mixins.json
@@ -3,7 +3,8 @@
   "package": "com.vanillastar.vsbrewing.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "potion.PotionsMixin"
+    "potion.PotionsMixin",
+    "recipe.BrewingRecipeRegistryBuilderMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Add new potion recipes, where FSE is fermented spider eye:

- Water + Redstone → Thick
- Awkward + Poisonous potato → Poison
- Leaping II + FSE → Slowness IV
- Poison (long) + FSE → Harming
- Strength + FSE → Weakness
- Strength II + FSE → Weakness II
- Strength (long) + FSE → Weakness (long)
- Swiftness II + FSE → Slowness IV
- Regeneration + FSE → Poison
- Regeneration II + FSE → Poison II
- Regeneration (long) + FSE → Poison (long)
- Weakness + Glowstone dust → Weakness II

Removed vanilla potion recipes for consistency:

- Water + Redstone → Mundane

Also reordered tooltip order for potion flask remaining uses, and reordered item group order for flask items.